### PR TITLE
Making the vault not reentrant to improve security

### DIFF
--- a/contracts/protocol/interfaces/ITransparentVault.sol
+++ b/contracts/protocol/interfaces/ITransparentVault.sol
@@ -178,7 +178,7 @@ interface ITransparentVault {
     address beneficiary
   ) external;
 
-  function amountsOf(
+  function amountOf(
     uint256 protectorId,
     address[] memory asset,
     uint256[] memory id

--- a/contracts/protocol/interfaces/ITransparentVault.sol
+++ b/contracts/protocol/interfaces/ITransparentVault.sol
@@ -178,7 +178,7 @@ interface ITransparentVault {
     address beneficiary
   ) external;
 
-  function ownedAssetsAmounts(
+  function amountsOf(
     uint256 protectorId,
     address[] memory asset,
     uint256[] memory id

--- a/contracts/protocol/transparentVault/TransparentVault.sol
+++ b/contracts/protocol/transparentVault/TransparentVault.sol
@@ -450,7 +450,7 @@ contract TransparentVault is
   // External services who need to see what a transparent vault contains can call
   // the Cruna Web API to get the list of assets owned by a protector. Then, they can call
   // this view to validate the results.
-  function amountsOf(
+  function amountOf(
     uint256 protectorId,
     address[] memory asset,
     uint256[] memory id

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/cruna-cc/cruna-protocol#readme",
   "license": "GPL3",
   "devDependencies": {
-    "@ndujalabs/erc721subordinate": "^0.6.2",
+    "@ndujalabs/erc721subordinate": "^0.6.3",
     "@nomiclabs/hardhat-ethers": "^2.0.3",
     "@nomiclabs/hardhat-etherscan": "^2.1.8",
     "@nomiclabs/hardhat-waffle": "^2.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: 5.4
 
 specifiers:
-  '@ndujalabs/erc721subordinate': ^0.6.2
+  '@ndujalabs/erc721subordinate': ^0.6.3
   '@nomiclabs/hardhat-ethers': ^2.0.3
   '@nomiclabs/hardhat-etherscan': ^2.1.8
   '@nomiclabs/hardhat-waffle': ^2.0.1
@@ -24,7 +24,7 @@ specifiers:
   typescript: ^4.7.3
 
 devDependencies:
-  '@ndujalabs/erc721subordinate': 0.6.2
+  '@ndujalabs/erc721subordinate': 0.6.3
   '@nomiclabs/hardhat-ethers': 2.0.4_metsxjxup4hfgxkchphssyuv5e
   '@nomiclabs/hardhat-etherscan': 2.1.8_hardhat@2.12.7
   '@nomiclabs/hardhat-waffle': 2.0.2_qwx25yt3ygbkd3hprmbcpvxm3i
@@ -497,8 +497,8 @@ packages:
       tweetnacl-util: 0.15.1
     dev: true
 
-  /@ndujalabs/erc721subordinate/0.6.2:
-    resolution: {integrity: sha512-g9dylKYyS4lHrJ6EXOY6mvr+IKH0T5KBXJCWYaxtlneZME5BMSEVp3uy+/pD63zsYzBgegnueT4BPJJSCTb+KA==}
+  /@ndujalabs/erc721subordinate/0.6.3:
+    resolution: {integrity: sha512-aIPWojJbbbjHbb8CmxUZEsw13ntELBbDyJY21fQk1/3DLnZtv13H8Q4y1Fc3fg1qPIWtcUtIuqMTojQ5cpJgzw==}
     dev: true
 
   /@noble/hashes/1.1.1:

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -109,17 +109,17 @@ describe("Integration", function () {
     // bob creates a vault depositing a particle token
     await particle.connect(bob).setApprovalForAll(everdragons2TransparentVault.address, true);
     await everdragons2TransparentVault.connect(bob).depositERC721(1, particle.address, 2);
-    expect((await everdragons2TransparentVault.amountsOf(1, [particle.address], [2]))[0]).equal(1);
+    expect((await everdragons2TransparentVault.amountOf(1, [particle.address], [2]))[0]).equal(1);
 
     // bob adds a stupidMonk token to his vault
     await stupidMonk.connect(bob).setApprovalForAll(everdragons2TransparentVault.address, true);
     await everdragons2TransparentVault.connect(bob).depositERC721(1, stupidMonk.address, 1);
-    expect((await everdragons2TransparentVault.amountsOf(1, [stupidMonk.address], [1]))[0]).equal(1);
+    expect((await everdragons2TransparentVault.amountOf(1, [stupidMonk.address], [1]))[0]).equal(1);
 
     // bob adds some bulls tokens to his vault
     await bulls.connect(bob).approve(everdragons2TransparentVault.address, amount("10000"));
     await everdragons2TransparentVault.connect(bob).depositERC20(1, bulls.address, amount("5000"));
-    expect((await everdragons2TransparentVault.amountsOf(1, [bulls.address], [0]))[0]).equal(amount("5000"));
+    expect((await everdragons2TransparentVault.amountOf(1, [bulls.address], [0]))[0]).equal(amount("5000"));
 
     // the protected cannot be transferred
     await expect(transferNft(everdragons2TransparentVault, bob)(bob.address, alice.address, 1)).revertedWith(
@@ -136,7 +136,7 @@ describe("Integration", function () {
     // bob creates a vault depositing a particle token
     await particle.connect(bob).setApprovalForAll(everdragons2TransparentVault.address, true);
     await everdragons2TransparentVault.connect(bob).depositERC721(1, particle.address, 2);
-    expect((await everdragons2TransparentVault.amountsOf(1, [particle.address], [2]))[0]).equal(1);
+    expect((await everdragons2TransparentVault.amountOf(1, [particle.address], [2]))[0]).equal(1);
 
     await expect(everdragons2Protector.connect(bob).setInitiator(mark.address))
       .emit(everdragons2Protector, "InitiatorStarted")
@@ -152,7 +152,7 @@ describe("Integration", function () {
     // bob creates a vault depositing a particle token
     await particle.connect(bob).setApprovalForAll(everdragons2TransparentVault.address, true);
     await everdragons2TransparentVault.connect(bob).depositERC721(1, particle.address, 2);
-    expect((await everdragons2TransparentVault.amountsOf(1, [particle.address], [2]))[0]).equal(1);
+    expect((await everdragons2TransparentVault.amountOf(1, [particle.address], [2]))[0]).equal(1);
 
     await expect(everdragons2Protector.connect(bob).setInitiator(mark.address))
       .emit(everdragons2Protector, "InitiatorStarted")
@@ -169,7 +169,7 @@ describe("Integration", function () {
     // bob creates a vault depositing a particle token
     await particle.connect(bob).setApprovalForAll(everdragons2TransparentVault.address, true);
     await everdragons2TransparentVault.connect(bob).depositERC721(1, particle.address, 2);
-    expect((await everdragons2TransparentVault.amountsOf(1, [particle.address], [2]))[0]).equal(1);
+    expect((await everdragons2TransparentVault.amountOf(1, [particle.address], [2]))[0]).equal(1);
 
     await expect(everdragons2Protector.connect(bob).setInitiator(mark.address))
       .emit(everdragons2Protector, "InitiatorStarted")

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -109,17 +109,17 @@ describe("Integration", function () {
     // bob creates a vault depositing a particle token
     await particle.connect(bob).setApprovalForAll(everdragons2TransparentVault.address, true);
     await everdragons2TransparentVault.connect(bob).depositERC721(1, particle.address, 2);
-    expect((await everdragons2TransparentVault.ownedAssetsAmounts(1, [particle.address], [2]))[0]).equal(1);
+    expect((await everdragons2TransparentVault.amountsOf(1, [particle.address], [2]))[0]).equal(1);
 
     // bob adds a stupidMonk token to his vault
     await stupidMonk.connect(bob).setApprovalForAll(everdragons2TransparentVault.address, true);
     await everdragons2TransparentVault.connect(bob).depositERC721(1, stupidMonk.address, 1);
-    expect((await everdragons2TransparentVault.ownedAssetsAmounts(1, [stupidMonk.address], [1]))[0]).equal(1);
+    expect((await everdragons2TransparentVault.amountsOf(1, [stupidMonk.address], [1]))[0]).equal(1);
 
     // bob adds some bulls tokens to his vault
     await bulls.connect(bob).approve(everdragons2TransparentVault.address, amount("10000"));
     await everdragons2TransparentVault.connect(bob).depositERC20(1, bulls.address, amount("5000"));
-    expect((await everdragons2TransparentVault.ownedAssetsAmounts(1, [bulls.address], [0]))[0]).equal(amount("5000"));
+    expect((await everdragons2TransparentVault.amountsOf(1, [bulls.address], [0]))[0]).equal(amount("5000"));
 
     // the protected cannot be transferred
     await expect(transferNft(everdragons2TransparentVault, bob)(bob.address, alice.address, 1)).revertedWith(
@@ -136,7 +136,7 @@ describe("Integration", function () {
     // bob creates a vault depositing a particle token
     await particle.connect(bob).setApprovalForAll(everdragons2TransparentVault.address, true);
     await everdragons2TransparentVault.connect(bob).depositERC721(1, particle.address, 2);
-    expect((await everdragons2TransparentVault.ownedAssetsAmounts(1, [particle.address], [2]))[0]).equal(1);
+    expect((await everdragons2TransparentVault.amountsOf(1, [particle.address], [2]))[0]).equal(1);
 
     await expect(everdragons2Protector.connect(bob).setInitiator(mark.address))
       .emit(everdragons2Protector, "InitiatorStarted")
@@ -152,7 +152,7 @@ describe("Integration", function () {
     // bob creates a vault depositing a particle token
     await particle.connect(bob).setApprovalForAll(everdragons2TransparentVault.address, true);
     await everdragons2TransparentVault.connect(bob).depositERC721(1, particle.address, 2);
-    expect((await everdragons2TransparentVault.ownedAssetsAmounts(1, [particle.address], [2]))[0]).equal(1);
+    expect((await everdragons2TransparentVault.amountsOf(1, [particle.address], [2]))[0]).equal(1);
 
     await expect(everdragons2Protector.connect(bob).setInitiator(mark.address))
       .emit(everdragons2Protector, "InitiatorStarted")
@@ -169,7 +169,7 @@ describe("Integration", function () {
     // bob creates a vault depositing a particle token
     await particle.connect(bob).setApprovalForAll(everdragons2TransparentVault.address, true);
     await everdragons2TransparentVault.connect(bob).depositERC721(1, particle.address, 2);
-    expect((await everdragons2TransparentVault.ownedAssetsAmounts(1, [particle.address], [2]))[0]).equal(1);
+    expect((await everdragons2TransparentVault.amountsOf(1, [particle.address], [2]))[0]).equal(1);
 
     await expect(everdragons2Protector.connect(bob).setInitiator(mark.address))
       .emit(everdragons2Protector, "InitiatorStarted")


### PR DESCRIPTION
- Make the vault non reentrant to improve security. The _nonReentrant_ modifier is applied during deposits and withdrawals.
- Rename the function `ownedAssetsAmounts` to `amountOf`.
- Update dependencies to ERC721Subordinate v0.6.3 to improve security.

