### PR TITLE
Reducing size

### DIFF
--- a/contracts/utils/ITokenUtils.sol
+++ b/contracts/utils/ITokenUtils.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.19;
 // Author: Francesco Sullo <francesco@sullo.co>
 
 //import "hardhat/console.sol";
+import "../vaults/IFlexiVault.sol";
 
 interface ITokenUtils {
   function isTokenUtils() external pure returns (bytes4);
@@ -26,6 +27,7 @@ interface ITokenUtils {
 
   function hashWithdrawsRequest(
     uint256 owningTokenId,
+    IFlexiVault.TokenType[] memory tokenTypes,
     address[] memory assets,
     uint256[] memory ids,
     uint256[] memory amounts,

--- a/contracts/utils/TokenUtils.sol
+++ b/contracts/utils/TokenUtils.sol
@@ -9,6 +9,7 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
 
 import "../protected-nft/IProtectedERC721.sol";
+import "../vaults/IFlexiVault.sol";
 
 //import "hardhat/console.sol";
 
@@ -70,6 +71,7 @@ library TokenUtils {
 
   function hashWithdrawsRequest(
     uint256 owningTokenId,
+    IFlexiVault.TokenType[] memory tokenTypes,
     address[] memory assets,
     uint256[] memory ids,
     uint256[] memory amounts,
@@ -84,6 +86,7 @@ library TokenUtils {
           block.chainid,
           address(this),
           owningTokenId,
+          tokenTypes,
           assets,
           ids,
           amounts,

--- a/contracts/vaults/FlexiVault.sol
+++ b/contracts/vaults/FlexiVault.sol
@@ -134,39 +134,39 @@ contract FlexiVault is IFlexiVaultExtended, IVersioned, Ownable, NFTOwned, Reent
     _registry.createAccount(account, block.chainid, address(trustee), owningTokenId, _salt, "");
   }
 
-  /**
-   * @dev {See IFlexiVault-depositERC721}
-   */
-  function depositERC721(
-    uint256 owningTokenId,
-    address asset,
-    uint256 id
-  ) public override nonReentrant onlyIfActiveAndOwningTokenNotApproved(owningTokenId) {
-    _depositERC721(owningTokenId, asset, id);
-  }
-
-  /**
-   * @dev {See IFlexiVault-depositERC20}
-   */
-  function depositERC20(
-    uint256 owningTokenId,
-    address asset,
-    uint256 amount
-  ) public override nonReentrant onlyIfActiveAndOwningTokenNotApproved(owningTokenId) {
-    _depositERC20(owningTokenId, asset, amount);
-  }
-
-  /**
-   * @dev {See IFlexiVault-depositERC1155}
-   */
-  function depositERC1155(
-    uint256 owningTokenId,
-    address asset,
-    uint256 id,
-    uint256 amount
-  ) public override nonReentrant onlyIfActiveAndOwningTokenNotApproved(owningTokenId) {
-    _depositERC1155(owningTokenId, asset, id, amount);
-  }
+  //  /**
+  //   * @dev {See IFlexiVault-depositERC721}
+  //   */
+  //  function depositERC721(
+  //    uint256 owningTokenId,
+  //    address asset,
+  //    uint256 id
+  //  ) public override nonReentrant onlyIfActiveAndOwningTokenNotApproved(owningTokenId) {
+  //    _depositERC721(owningTokenId, asset, id);
+  //  }
+  //
+  //  /**
+  //   * @dev {See IFlexiVault-depositERC20}
+  //   */
+  //  function depositERC20(
+  //    uint256 owningTokenId,
+  //    address asset,
+  //    uint256 amount
+  //  ) public override nonReentrant onlyIfActiveAndOwningTokenNotApproved(owningTokenId) {
+  //    _depositERC20(owningTokenId, asset, amount);
+  //  }
+  //
+  //  /**
+  //   * @dev {See IFlexiVault-depositERC1155}
+  //   */
+  //  function depositERC1155(
+  //    uint256 owningTokenId,
+  //    address asset,
+  //    uint256 id,
+  //    uint256 amount
+  //  ) public override nonReentrant onlyIfActiveAndOwningTokenNotApproved(owningTokenId) {
+  //    _depositERC1155(owningTokenId, asset, id, amount);
+  //  }
 
   function _depositERC721(uint256 owningTokenId, address asset, uint256 id) internal {
     // the following reverts if not an ERC721. We do not pre-check to save gas.
@@ -176,7 +176,13 @@ contract FlexiVault is IFlexiVaultExtended, IVersioned, Ownable, NFTOwned, Reent
   /**
    * @dev {See IFlexiVault-depositETH}
    */
-  function depositETH(uint256 owningTokenId) external payable override onlyIfActiveAndOwningTokenNotApproved(owningTokenId) {
+  //  function depositETH(uint256 owningTokenId) external payable override onlyIfActiveAndOwningTokenNotApproved(owningTokenId) {
+  //    if (msg.value == 0) revert NoETH();
+  //    (bool success, ) = payable(_accountAddresses[owningTokenId]).call{value: msg.value}("");
+  //    if (!success) revert ETHDepositFailed();
+  //  }
+
+  function _depositETH(uint256 owningTokenId) internal {
     if (msg.value == 0) revert NoETH();
     (bool success, ) = payable(_accountAddresses[owningTokenId]).call{value: msg.value}("");
     if (!success) revert ETHDepositFailed();
@@ -201,10 +207,12 @@ contract FlexiVault is IFlexiVaultExtended, IVersioned, Ownable, NFTOwned, Reent
     address[] memory assets,
     uint256[] memory ids, // 0 for ERC20
     uint256[] memory amounts // 1 for ERC721
-  ) external override nonReentrant onlyIfActiveAndOwningTokenNotApproved(owningTokenId) {
+  ) external payable override nonReentrant onlyIfActiveAndOwningTokenNotApproved(owningTokenId) {
     if (assets.length != ids.length || assets.length != amounts.length) revert InconsistentLengths();
     for (uint256 i = 0; i < assets.length; i++) {
-      if (ids[i] == 0 && _tokenUtils.isERC20(assets[i])) {
+      if (ids[i] == 0 && assets[i] == address(0)) {
+        _depositETH(owningTokenId);
+      } else if (ids[i] == 0 && _tokenUtils.isERC20(assets[i])) {
         _depositERC20(owningTokenId, assets[i], amounts[i]);
       } else if (amounts[i] == 1 && _tokenUtils.isERC721(assets[i])) {
         _depositERC721(owningTokenId, assets[i], ids[i]);
@@ -274,22 +282,22 @@ contract FlexiVault is IFlexiVaultExtended, IVersioned, Ownable, NFTOwned, Reent
   /**
    * @dev {See IFlexiVault-withdrawAsset}
    */
-  function withdrawAsset(
-    uint256 owningTokenId,
-    address asset, // if address(0) we want to withdraw the native token, for example Ether
-    uint256 id,
-    uint256 amount,
-    address beneficiary // if address(0) we send to the owner of the owningTokenId
-  )
-    public
-    override
-    onlyOwningTokenOwnerOrOperator(owningTokenId)
-    onlyIfActiveAndOwningTokenNotApproved(owningTokenId)
-    nonReentrant
-  {
-    _isChangeAllowed(owningTokenId);
-    _withdrawAsset(owningTokenId, asset, id, amount, beneficiary);
-  }
+  //  function withdrawAsset(
+  //    uint256 owningTokenId,
+  //    address asset, // if address(0) we want to withdraw the native token, for example Ether
+  //    uint256 id,
+  //    uint256 amount,
+  //    address beneficiary // if address(0) we send to the owner of the owningTokenId
+  //  )
+  //    public
+  //    override
+  //    onlyOwningTokenOwnerOrOperator(owningTokenId)
+  //    onlyIfActiveAndOwningTokenNotApproved(owningTokenId)
+  //    nonReentrant
+  //  {
+  //    _isChangeAllowed(owningTokenId);
+  //    _withdrawAsset(owningTokenId, asset, id, amount, beneficiary);
+  //  }
 
   /**
    * @dev {See IFlexiVault-withdrawAssets}
@@ -310,33 +318,33 @@ contract FlexiVault is IFlexiVaultExtended, IVersioned, Ownable, NFTOwned, Reent
     _isChangeAllowed(owningTokenId);
     if (assets.length != ids.length || assets.length != amounts.length) revert InconsistentLengths();
     for (uint256 i = 0; i < assets.length; i++) {
-      withdrawAsset(owningTokenId, assets[i], ids[i], amounts[i], beneficiaries[i]);
+      _withdrawAsset(owningTokenId, assets[i], ids[i], amounts[i], beneficiaries[i]);
     }
   }
 
   /**
    * @dev {See IFlexiVault-protectedWithdrawAsset}
    */
-  function protectedWithdrawAsset(
-    uint256 owningTokenId,
-    address asset,
-    uint256 id,
-    uint256 amount,
-    address beneficiary,
-    uint256 timestamp,
-    uint validFor,
-    bytes calldata signature
-  )
-    public
-    override
-    onlyOwningTokenOwnerOrOperator(owningTokenId)
-    onlyIfActiveAndOwningTokenNotApproved(owningTokenId)
-    nonReentrant
-  {
-    bytes32 hash = _tokenUtils.hashWithdrawRequest(owningTokenId, asset, id, amount, beneficiary, timestamp, validFor);
-    _protectedOwningToken.validateTimestampAndSignature(owningTokenId, timestamp, validFor, hash, signature);
-    _withdrawAsset(owningTokenId, asset, id, amount, beneficiary);
-  }
+  //  function protectedWithdrawAsset(
+  //    uint256 owningTokenId,
+  //    address asset,
+  //    uint256 id,
+  //    uint256 amount,
+  //    address beneficiary,
+  //    uint256 timestamp,
+  //    uint validFor,
+  //    bytes calldata signature
+  //  )
+  //    public
+  //    override
+  //    onlyOwningTokenOwnerOrOperator(owningTokenId)
+  //    onlyIfActiveAndOwningTokenNotApproved(owningTokenId)
+  //    nonReentrant
+  //  {
+  //    bytes32 hash = _tokenUtils.hashWithdrawRequest(owningTokenId, asset, id, amount, beneficiary, timestamp, validFor);
+  //    _protectedOwningToken.validateTimestampAndSignature(owningTokenId, timestamp, validFor, hash, signature);
+  //    _withdrawAsset(owningTokenId, asset, id, amount, beneficiary);
+  //  }
 
   /**
    * @dev {See IFlexiVault-protectedWithdrawAssets}

--- a/contracts/vaults/IFlexiVault.sol
+++ b/contracts/vaults/IFlexiVault.sol
@@ -4,6 +4,13 @@ pragma solidity ^0.8.19;
 // Author: Francesco Sullo <francesco@sullo.co>
 
 interface IFlexiVault {
+  enum TokenType {
+    ETH,
+    ERC20,
+    ERC721,
+    ERC1155
+  }
+
   /**
    * @dev It checks if the contract is a Transparent Vault
    * @return bytes4(keccak256('isFlexiVault()')) if the contract is a Transparent Vault
@@ -25,40 +32,10 @@ interface IFlexiVault {
    */
   function init(address registry, address payable boundAccount, address payable boundAccountUpgradeable) external;
 
-  //  /**
-  //   * @dev Deposits Ether in the bound account
-  //   * @param owningTokenId The id of the owning token
-  //   */
-  //  function depositETH(uint256 owningTokenId) external payable;
-
-  //  /**
-  //   * @dev Deposits ERC721 in the bound account
-  //   * @param owningTokenId The id of the owning token
-  //   * @param asset The address of the ERC721 contract
-  //   * @param id The id of the ERC721 token
-  //   */
-  //  function depositERC721(uint256 owningTokenId, address asset, uint256 id) external;
-
-  //  /**
-  //   * @dev Deposits ERC20 in the bound account
-  //   * @param owningTokenId The id of the owning token
-  //   * @param asset The address of the ERC20 contract
-  //   * @param amount The amount of the ERC20 token
-  //   */
-  //  function depositERC20(uint256 owningTokenId, address asset, uint256 amount) external;
-
-  //  /**
-  //   * @dev Deposits ERC1155 in the bound account
-  //   * @param owningTokenId The id of the owning token
-  //   * @param asset The address of the ERC1155 contract
-  //   * @param id The id of the ERC1155 token
-  //   * @param amount The amount of the ERC1155 token
-  //   */
-  //  function depositERC1155(uint256 owningTokenId, address asset, uint256 id, uint256 amount) external;
-
   /**
    * @dev Deposits multiple assets in the bound account
    * @param owningTokenId The id of the owning token
+   * @param tokenTypes The types of the assets tokens
    * @param assets The addresses of the assets
    * @param ids The ids of the assets tokens
       If the asset is an ERC20, the id is 0
@@ -67,45 +44,11 @@ interface IFlexiVault {
    */
   function depositAssets(
     uint256 owningTokenId,
+    TokenType[] memory tokenTypes,
     address[] memory assets,
     uint256[] memory ids,
     uint256[] memory amounts
   ) external payable;
-
-  //  /**
-  //   * @dev Withdraws an asset from the bound account
-  //   * @param owningTokenId The id of the owning token
-  //   * @param asset The address of the asset
-  //      If the asset is the native token, for example Ether, the address is address(0)
-  //   * @param id The id of the asset token
-  //      If the asset is an ERC20, the id is 0
-  //   * @param amount The amount of the asset token
-  //      If the asset is an ERC721, the amount is 1
-  //   * @param beneficiary The address of the beneficiary
-  //   */
-  //  function withdrawAsset(uint256 owningTokenId, address asset, uint256 id, uint256 amount, address beneficiary) external;
-
-  //  /**
-  //   * @dev Withdraws an asset from the bound account when a protector is active
-  //   * @param owningTokenId The id of the owning token
-  //   * @param asset The address of the asset
-  //   * @param id The id of the asset token
-  //   * @param amount The amount of the asset token
-  //   * @param beneficiary The address of the beneficiary
-  //   * @param timestamp The timestamp of the request
-  //   * @param validFor The time the request is valid for
-  //   * @param signature The signature of the protector
-  //   */
-  //  function protectedWithdrawAsset(
-  //    uint256 owningTokenId,
-  //    address asset, // if address(0) we want to withdraw the native token, for example Ether
-  //    uint256 id,
-  //    uint256 amount,
-  //    address beneficiary,
-  //    uint256 timestamp,
-  //    uint validFor,
-  //    bytes calldata signature
-  //  ) external;
 
   /**
    * @dev Withdraws multiple assets from the bound account
@@ -120,6 +63,7 @@ interface IFlexiVault {
    */
   function withdrawAssets(
     uint owningTokenId,
+    TokenType[] memory tokenTypes,
     address[] memory assets,
     uint256[] memory ids,
     uint256[] memory amounts,
@@ -139,6 +83,7 @@ interface IFlexiVault {
    */
   function protectedWithdrawAssets(
     uint256 owningTokenId,
+    TokenType[] memory tokenTypes,
     address[] memory assets,
     uint256[] memory ids,
     uint256[] memory amounts,

--- a/contracts/vaults/IFlexiVault.sol
+++ b/contracts/vaults/IFlexiVault.sol
@@ -25,36 +25,36 @@ interface IFlexiVault {
    */
   function init(address registry, address payable boundAccount, address payable boundAccountUpgradeable) external;
 
-  /**
-   * @dev Deposits Ether in the bound account
-   * @param owningTokenId The id of the owning token
-   */
-  function depositETH(uint256 owningTokenId) external payable;
+  //  /**
+  //   * @dev Deposits Ether in the bound account
+  //   * @param owningTokenId The id of the owning token
+  //   */
+  //  function depositETH(uint256 owningTokenId) external payable;
 
-  /**
-   * @dev Deposits ERC721 in the bound account
-   * @param owningTokenId The id of the owning token
-   * @param asset The address of the ERC721 contract
-   * @param id The id of the ERC721 token
-   */
-  function depositERC721(uint256 owningTokenId, address asset, uint256 id) external;
+  //  /**
+  //   * @dev Deposits ERC721 in the bound account
+  //   * @param owningTokenId The id of the owning token
+  //   * @param asset The address of the ERC721 contract
+  //   * @param id The id of the ERC721 token
+  //   */
+  //  function depositERC721(uint256 owningTokenId, address asset, uint256 id) external;
 
-  /**
-   * @dev Deposits ERC20 in the bound account
-   * @param owningTokenId The id of the owning token
-   * @param asset The address of the ERC20 contract
-   * @param amount The amount of the ERC20 token
-   */
-  function depositERC20(uint256 owningTokenId, address asset, uint256 amount) external;
+  //  /**
+  //   * @dev Deposits ERC20 in the bound account
+  //   * @param owningTokenId The id of the owning token
+  //   * @param asset The address of the ERC20 contract
+  //   * @param amount The amount of the ERC20 token
+  //   */
+  //  function depositERC20(uint256 owningTokenId, address asset, uint256 amount) external;
 
-  /**
-   * @dev Deposits ERC1155 in the bound account
-   * @param owningTokenId The id of the owning token
-   * @param asset The address of the ERC1155 contract
-   * @param id The id of the ERC1155 token
-   * @param amount The amount of the ERC1155 token
-   */
-  function depositERC1155(uint256 owningTokenId, address asset, uint256 id, uint256 amount) external;
+  //  /**
+  //   * @dev Deposits ERC1155 in the bound account
+  //   * @param owningTokenId The id of the owning token
+  //   * @param asset The address of the ERC1155 contract
+  //   * @param id The id of the ERC1155 token
+  //   * @param amount The amount of the ERC1155 token
+  //   */
+  //  function depositERC1155(uint256 owningTokenId, address asset, uint256 id, uint256 amount) external;
 
   /**
    * @dev Deposits multiple assets in the bound account
@@ -70,42 +70,42 @@ interface IFlexiVault {
     address[] memory assets,
     uint256[] memory ids,
     uint256[] memory amounts
-  ) external;
+  ) external payable;
 
-  /**
-   * @dev Withdraws an asset from the bound account
-   * @param owningTokenId The id of the owning token
-   * @param asset The address of the asset
-      If the asset is the native token, for example Ether, the address is address(0)
-   * @param id The id of the asset token
-      If the asset is an ERC20, the id is 0
-   * @param amount The amount of the asset token
-      If the asset is an ERC721, the amount is 1
-   * @param beneficiary The address of the beneficiary
-   */
-  function withdrawAsset(uint256 owningTokenId, address asset, uint256 id, uint256 amount, address beneficiary) external;
+  //  /**
+  //   * @dev Withdraws an asset from the bound account
+  //   * @param owningTokenId The id of the owning token
+  //   * @param asset The address of the asset
+  //      If the asset is the native token, for example Ether, the address is address(0)
+  //   * @param id The id of the asset token
+  //      If the asset is an ERC20, the id is 0
+  //   * @param amount The amount of the asset token
+  //      If the asset is an ERC721, the amount is 1
+  //   * @param beneficiary The address of the beneficiary
+  //   */
+  //  function withdrawAsset(uint256 owningTokenId, address asset, uint256 id, uint256 amount, address beneficiary) external;
 
-  /**
-   * @dev Withdraws an asset from the bound account when a protector is active
-   * @param owningTokenId The id of the owning token
-   * @param asset The address of the asset
-   * @param id The id of the asset token
-   * @param amount The amount of the asset token
-   * @param beneficiary The address of the beneficiary
-   * @param timestamp The timestamp of the request
-   * @param validFor The time the request is valid for
-   * @param signature The signature of the protector
-   */
-  function protectedWithdrawAsset(
-    uint256 owningTokenId,
-    address asset, // if address(0) we want to withdraw the native token, for example Ether
-    uint256 id,
-    uint256 amount,
-    address beneficiary,
-    uint256 timestamp,
-    uint validFor,
-    bytes calldata signature
-  ) external;
+  //  /**
+  //   * @dev Withdraws an asset from the bound account when a protector is active
+  //   * @param owningTokenId The id of the owning token
+  //   * @param asset The address of the asset
+  //   * @param id The id of the asset token
+  //   * @param amount The amount of the asset token
+  //   * @param beneficiary The address of the beneficiary
+  //   * @param timestamp The timestamp of the request
+  //   * @param validFor The time the request is valid for
+  //   * @param signature The signature of the protector
+  //   */
+  //  function protectedWithdrawAsset(
+  //    uint256 owningTokenId,
+  //    address asset, // if address(0) we want to withdraw the native token, for example Ether
+  //    uint256 id,
+  //    uint256 amount,
+  //    address beneficiary,
+  //    uint256 timestamp,
+  //    uint validFor,
+  //    bytes calldata signature
+  //  ) external;
 
   /**
    * @dev Withdraws multiple assets from the bound account

--- a/contracts/vaults/IFlexiVaultExtended.sol
+++ b/contracts/vaults/IFlexiVaultExtended.sol
@@ -35,10 +35,4 @@ interface IFlexiVaultExtended is IFlexiVault {
   error OwningTokenNotProtected();
   error VaultHasBeenUpgraded();
   error InvalidTokenUtils();
-
-  enum TokenType {
-    ERC20,
-    ERC721,
-    ERC1155
-  }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "clean": "rimraf artifacts cache coverage coverage.json",
     "test": "NODE_ENV=test npx hardhat test",
-    "test:gas": "NODE_ENV=test GAS_REPORT=true npx hardhat test",
+    "test:gas": "NODE_ENV=test GAS_REPORT=yes npx hardhat test",
     "compile": "NODE_ENV=test npx hardhat compile",
     "compile:one": "NODE_ENV=test npx hardhat compile --file contracts/$1.sol",
     "lint": "prettier --write 'contracts/**/*.sol' && solhint 'contracts/**/*.sol' && npx prettier --write ./test/**/*.js ./**/*.js",

--- a/test/FlexiVault.test.js
+++ b/test/FlexiVault.test.js
@@ -86,7 +86,7 @@ describe("FlexiVault", function () {
   it("should revert if not activated", async function () {
     // bob creates a vaults depositing a particle token
     await particle.connect(bob).setApprovalForAll(flexiVault.address, true);
-    await expect(flexiVault.connect(bob).depositERC721(1, particle.address, 2)).revertedWith("NotActivated()");
+    await expect(flexiVault.connect(bob).depositAssets(1, [particle.address], [2], [1])).revertedWith("NotActivated()");
   });
 
   it("should create a vaults and add more assets to it", async function () {
@@ -94,17 +94,19 @@ describe("FlexiVault", function () {
 
     // bob creates a vaults depositing a particle token
     await particle.connect(bob).setApprovalForAll(flexiVault.address, true);
-    await flexiVault.connect(bob).depositERC721(1, particle.address, 2);
-    expect((await flexiVault.amountOf(1, [particle.address], [2]))[0]).equal(1);
 
     // bob adds a stupidMonk token to his vaults
     await stupidMonk.connect(bob).setApprovalForAll(flexiVault.address, true);
-    await flexiVault.connect(bob).depositERC721(1, stupidMonk.address, 1);
-    expect((await flexiVault.amountOf(1, [stupidMonk.address], [1]))[0]).equal(1);
 
     // bob adds some bulls tokens to his vaults
     await bulls.connect(bob).approve(flexiVault.address, amount("10000"));
-    await flexiVault.connect(bob).depositERC20(1, bulls.address, amount("5000"));
+
+    await flexiVault
+      .connect(bob)
+      .depositAssets(1, [particle.address, stupidMonk.address, bulls.address], [2, 1, 0], [1, 1, amount("5000")]);
+
+    expect((await flexiVault.amountOf(1, [particle.address], [2]))[0]).equal(1);
+    expect((await flexiVault.amountOf(1, [stupidMonk.address], [1]))[0]).equal(1);
     expect((await flexiVault.amountOf(1, [bulls.address], [0]))[0]).equal(amount("5000"));
 
     // bob transfers the protected to alice
@@ -114,11 +116,7 @@ describe("FlexiVault", function () {
 
     expect(await stupidMonk.balanceOf(fred.address)).equal(0);
 
-    await expect(
-      flexiVault
-        .connect(alice)
-        ["withdrawAsset(uint256,address,uint256,uint256,address)"](1, stupidMonk.address, 1, 1, fred.address)
-    )
+    await expect(flexiVault.connect(alice).withdrawAssets(1, [stupidMonk.address], [1], [1], [fred.address]))
       .emit(flexiVault, "Withdrawal")
       .emit(stupidMonk, "Transfer");
 
@@ -151,7 +149,7 @@ describe("FlexiVault", function () {
   it("should create a vaults and deposit Ether ", async function () {
     await flexiVault.connect(bob).activateAccount(1, true);
 
-    await flexiVault.connect(bob).depositETH(1, {value: amount("1000")});
+    await flexiVault.connect(bob).depositAssets(1, [ethers.constants.AddressZero], [0], [0], {value: amount("1000")});
     expect((await flexiVault.amountOf(1, [ethers.constants.AddressZero], [0]))[0]).equal(amount("1000"));
 
     const accountAddress = await flexiVault.accountAddress(1);
@@ -162,19 +160,14 @@ describe("FlexiVault", function () {
   it("should create a vaults, add assets to it, then eject and reinject again", async function () {
     await flexiVault.connect(bob).activateAccount(1, true);
 
-    // bob creates a vaults depositing a particle token
     await particle.connect(bob).setApprovalForAll(flexiVault.address, true);
-    await flexiVault.connect(bob).depositERC721(1, particle.address, 2);
-    expect((await flexiVault.amountOf(1, [particle.address], [2]))[0]).equal(1);
-
-    // bob adds some UselessWeapons tokens to his vaults
     await uselessWeapons.connect(bob).setApprovalForAll(flexiVault.address, true);
-    await flexiVault.connect(bob).depositERC1155(1, uselessWeapons.address, 2, 2);
+    await flexiVault.connect(bob).depositAssets(1, [particle.address, uselessWeapons.address], [2, 2], [1, 2]);
     expect((await flexiVault.amountOf(1, [uselessWeapons.address], [2]))[0]).equal(2);
 
     // bob adds some bulls tokens to his vaults
     await bulls.connect(fred).approve(flexiVault.address, amount("10000"));
-    await flexiVault.connect(fred).depositERC20(1, bulls.address, amount("5000"));
+    await flexiVault.connect(fred).depositAssets(1, [bulls.address], [0], [amount("5000")]);
     expect((await flexiVault.amountOf(1, [bulls.address], [0]))[0]).equal(amount("5000"));
 
     const trusteeAddress = await flexiVault.trustee();
@@ -190,7 +183,9 @@ describe("FlexiVault", function () {
 
     await expect(flexiVault.connect(bob).ejectAccount(1)).revertedWith("AccountHasBeenEjected()");
 
-    await expect(flexiVault.connect(bob).depositERC721(1, particle.address, 4)).revertedWith("AccountHasBeenEjected()");
+    await expect(flexiVault.connect(bob).depositAssets(1, [particle.address], [4], [1])).revertedWith(
+      "AccountHasBeenEjected()"
+    );
 
     await trustee.connect(bob).approve(flexiVault.address, 1);
 
@@ -202,7 +197,7 @@ describe("FlexiVault", function () {
 
     const accountAddress = await flexiVault.accountAddress(1);
 
-    await expect(flexiVault.connect(bob).depositERC721(1, particle.address, 4))
+    await expect(flexiVault.connect(bob).depositAssets(1, [particle.address], [4], [1]))
       .emit(particle, "Transfer")
       .withArgs(bob.address, accountAddress, 4);
 
@@ -214,7 +209,7 @@ describe("FlexiVault", function () {
 
     // bob creates a vaults depositing a particle token
     await particle.connect(bob).setApprovalForAll(flexiVault.address, true);
-    await flexiVault.connect(bob).depositERC721(1, particle.address, 2);
+    await flexiVault.connect(bob).depositAssets(1, [particle.address], [2], [1]);
     expect((await flexiVault.amountOf(1, [particle.address], [2]))[0]).equal(1);
 
     await expect(crunaVault.connect(bob).proposeProtector(mark.address))
@@ -244,7 +239,7 @@ describe("FlexiVault", function () {
 
     // bob creates a vaults depositing a particle token
     await particle.connect(bob).setApprovalForAll(flexiVault.address, true);
-    await flexiVault.connect(bob).depositERC721(1, particle.address, 2);
+    await flexiVault.connect(bob).depositAssets(1, [particle.address], [2], [1]);
     expect((await flexiVault.amountOf(1, [particle.address], [2]))[0]).equal(1);
 
     await expect(crunaVault.connect(bob).proposeProtector(mark.address))

--- a/test/FlexiVault.test.js
+++ b/test/FlexiVault.test.js
@@ -13,8 +13,6 @@ describe("FlexiVault", function () {
   // wallets
   let owner, bob, alice, fred, john, jane, mark;
 
-  let ETH, ERC20, ERC721, ERC1155;
-
   before(async function () {
     [owner, bob, alice, fred, john, jane, mark] = await ethers.getSigners();
   });


### PR DESCRIPTION
Here we remove convenience function, like `depositERC20` in favor of batch functions.
The rationale is to reduce the size of the FlexiVault smart contract from more than 22Kb to 18.6Kb, leaving space for more functions.
The tradeoff is that the functions to be called are more complex.
However, the gas cost is almost the same, thanks to the usage in input of `TokenType` params to recognize what kind of token it is, instead of verifying the interface/selector. To have an idea, executing depositERC721 was costing ~100,000 gas, while using depositAssets it will cost ~104,000 gas.

Still, 100,000 gas is a lot and we should investigate to understand if there is something wrong in our approach that generate extra costs. I am afraid that is an extra-cost due to using a bound account.

In any case, we should invite the users to transfer directly assets from their wallets to their bound account, to minimize the costs.