### PR TITLE
Managing unmanaged reinjections

### DIFF
--- a/contracts/vaults/FlexiVault.sol
+++ b/contracts/vaults/FlexiVault.sol
@@ -356,8 +356,9 @@ contract FlexiVault is IFlexiVaultExtended, IERC721Receiver, IVersioned, Ownable
     emit EjectedBoundAccountReInjected(owningTokenId);
   }
 
-  // Some user may transfer the ownership of a TrusteeNFT to the FlexiVault without calling the reInjectEjectedAccount function.
-  // If that happens, the FlexiVault is unable to manage the TrusteeNFT, and the bound account would be lost.
+  /**
+   * @dev {See IFlexiVault-fixDirectlyInjectedAccount}
+   */
   function fixDirectlyInjectedAccount(uint256 owningTokenId) external override onlyOwningTokenOwner(owningTokenId) {
     if (!_ejects[owningTokenId]) revert TheAccountHasNeverBeenEjected();
     if (trustee.ownerOf(owningTokenId) != address(this)) revert TheAccountIsNotOwnedByTheFlexiVault();

--- a/contracts/vaults/FlexiVault.sol
+++ b/contracts/vaults/FlexiVault.sol
@@ -6,6 +6,7 @@ pragma solidity ^0.8.19;
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
+import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
@@ -23,7 +24,7 @@ import "../protected-nft/IActors.sol";
 
 //import "hardhat/console.sol";
 
-contract FlexiVault is IFlexiVaultExtended, IVersioned, Ownable, NFTOwned, ReentrancyGuard {
+contract FlexiVault is IFlexiVaultExtended, IERC721Receiver, IVersioned, Ownable, NFTOwned, ReentrancyGuard {
   mapping(bytes32 => uint256) private _unconfirmedDeposits;
 
   // modifiers
@@ -81,6 +82,10 @@ contract FlexiVault is IFlexiVaultExtended, IVersioned, Ownable, NFTOwned, Reent
    */
   function version() external pure override returns (string memory) {
     return "1.0.0";
+  }
+
+  function onERC721Received(address, address, uint256, bytes memory) external pure returns (bytes4) {
+    return this.onERC721Received.selector;
   }
 
   /**
@@ -347,6 +352,15 @@ contract FlexiVault is IFlexiVaultExtended, IVersioned, Ownable, NFTOwned, Reent
     if (!_ejects[owningTokenId]) revert NotAPreviouslyEjectedAccount();
     // the contract must be approved
     trustee.transferFrom(ownerOf(owningTokenId), address(this), owningTokenId);
+    delete _ejects[owningTokenId];
+    emit EjectedBoundAccountReInjected(owningTokenId);
+  }
+
+  // Some user may transfer the ownership of a TrusteeNFT to the FlexiVault without calling the reInjectEjectedAccount function.
+  // If that happens, the FlexiVault is unable to manage the TrusteeNFT, and the bound account would be lost.
+  function fixDirectlyInjectedAccount(uint256 owningTokenId) external override onlyOwningTokenOwner(owningTokenId) {
+    if (!_ejects[owningTokenId]) revert TheAccountHasNeverBeenEjected();
+    if (trustee.ownerOf(owningTokenId) != address(this)) revert TheAccountIsNotOwnedByTheFlexiVault();
     delete _ejects[owningTokenId];
     emit EjectedBoundAccountReInjected(owningTokenId);
   }

--- a/contracts/vaults/IFlexiVault.sol
+++ b/contracts/vaults/IFlexiVault.sol
@@ -129,4 +129,10 @@ interface IFlexiVault {
    * @param owningTokenId The id of the owning token
    */
   function reInjectEjectedAccount(uint256 owningTokenId) external;
+
+  /**
+   * @dev It fixes an account directly injected
+   * @param owningTokenId The id of the owning token
+   */
+  function fixDirectlyInjectedAccount(uint256 owningTokenId) external;
 }

--- a/contracts/vaults/IFlexiVault.sol
+++ b/contracts/vaults/IFlexiVault.sol
@@ -132,6 +132,8 @@ interface IFlexiVault {
 
   /**
    * @dev It fixes an account directly injected
+      Some user may transfer the ownership of a TrusteeNFT to the FlexiVault without calling the reInjectEjectedAccount function.
+      If that happens, the FlexiVault is unable to manage the TrusteeNFT, and the bound account would be lost.
    * @param owningTokenId The id of the owning token
    */
   function fixDirectlyInjectedAccount(uint256 owningTokenId) external;

--- a/contracts/vaults/IFlexiVaultExtended.sol
+++ b/contracts/vaults/IFlexiVaultExtended.sol
@@ -35,4 +35,6 @@ interface IFlexiVaultExtended is IFlexiVault {
   error OwningTokenNotProtected();
   error VaultHasBeenUpgraded();
   error InvalidTokenUtils();
+  error TheAccountHasNeverBeenEjected();
+  error TheAccountIsNotOwnedByTheFlexiVault();
 }


### PR DESCRIPTION
If a user eject an account and later transfer the TrusteeNFT directly to the FlexiVault, the latter does not know about it and is unable to manage it because of line 65 in the modifier
```
  if (_ejects[owningTokenId]) revert AccountHasBeenEjected();
```
This PR fixes this adding a function that checks in the owner of the trustee is the FlexiVault and deletes `_ejects[owningTokenId]`